### PR TITLE
Add support to run script on AWS Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
 *.egg-info
-dontspendtoomuch-lambda.zip
+dontspendtoomuch-deps.zip
+dontspendtoomuch-script.zip
 build-deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 venv
 *.egg-info
+dontspendtoomuch-lambda.zip
+build-deps/

--- a/Makefile
+++ b/Makefile
@@ -7,27 +7,35 @@ help :
 	@echo '  make lint                  run linter'
 	@echo '  make format                run code formatter, giving a diff for recommended changes'
 	@echo '  make venv                  prepare virtualenv'
-	@echo '  make lambda                build lambda-deployable zip archive'
+	@echo '  make lambda                build lambda-deployable zip archives'
 	@echo '  make deploy                rebuild lambda and push it up'
 	@echo
 
 .PHONY: deploy
-deploy: clean lambda
+deploy: deploy-deps deploy-script
+
+.PHONY: deploy-deps
+deploy-deps: dontspendtoomuch-deps.zip
+	terraform apply -target=aws_lambda_layer_version.dependencies
+
+.PHONY: deploy-script
+deploy-script: dontspendtoomuch-script.zip
 	terraform apply -target=aws_lambda_function.dontspendtoomuch
 
 .PHONY: lambda
-lambda: dontspendtoomuch-lambda.zip
-dontspendtoomuch-lambda.zip: venv dontspendtoomuch.py
+lambda: dontspendtoomuch-script.zip dontspendtoomuch-deps.zip
+dontspendtoomuch-deps.zip: venv setup.py
 # Install dependencies into a 'build-deps' directory
-	. venv/bin/activate; pip install --no-compile --no-cache-dir --target=./build-deps .
+	. venv/bin/activate; pip install --no-compile --no-cache-dir --target=./build-deps/python .
 # Delete python metadata; we won't be needing it up in lambda
 	find ./build-deps -name "*.dist-info" -depth -type d -exec rm -rf "{}" +
 # Bundle all the deps into a zip file. Make sure they're at the root level of
 # the resulting zip - we 'cd' in order to accomplish that.
-	cd build-deps; zip -r9 ../dontspendtoomuch-lambda.zip .
-# Add the main script, dontspendtoomuch.py, to the zip result
-	zip -g dontspendtoomuch-lambda.zip dontspendtoomuch.py
+	cd build-deps; zip -r9 ../dontspendtoomuch-deps.zip .
 	rm -rf ./build-deps
+
+dontspendtoomuch-script.zip: venv dontspendtoomuch.py
+	zip -r9 dontspendtoomuch-script.zip dontspendtoomuch.py
 
 .PHONY: test
 test: venv
@@ -52,5 +60,6 @@ clean:
 	rm -rf __pycache__
 	rm -rf .pytest_cache
 	rm -rf dontspendtoomuch.egg-info
-	rm -rf dontspendtoomuch-lambda.zip
+	rm -rf dontspendtoomuch-deps.zip
+	rm -rf dontspendtoomuch-script.zip
 	rm -rf ./build-deps

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ deploy: deploy-deps deploy-script
 
 .PHONY: deploy-deps
 deploy-deps: dontspendtoomuch-deps.zip
-	terraform apply -target=aws_lambda_layer_version.dependencies
+	aws s3 cp dontspendtoomuch-deps.zip s3://scimma-deployables/dontspendtoomuch/latest/dependencies.zip
 
 .PHONY: deploy-script
 deploy-script: dontspendtoomuch-script.zip
-	terraform apply -target=aws_lambda_function.dontspendtoomuch
+	aws s3 cp dontspendtoomuch-script.zip s3://scimma-deployables/dontspendtoomuch/latest/script.zip
 
 .PHONY: lambda
 lambda: dontspendtoomuch-script.zip dontspendtoomuch-deps.zip

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint: venv
 
 .PHONY: format
 format: venv
-	. venv/bin/activate; autopep8 .
+	. venv/bin/activate; autopep8 --in-place *.py
 
 venv: venv/bin/activate
 venv/bin/activate: setup.py

--- a/dontspendtoomuch.py
+++ b/dontspendtoomuch.py
@@ -97,9 +97,6 @@ def aws_date_string(date):
 def fetch(start, end):
     """Get data from AWS on cost and usage. Start and end should be strings in the
     format YYYY-MM-DD."""
-    print("initializing client")
-    id = boto3.client("sts").get_caller_identity()
-    print(f"identity: {id}")
     client = boto3.client("ce")
     return client.get_cost_and_usage(
         TimePeriod={

--- a/dontspendtoomuch.py
+++ b/dontspendtoomuch.py
@@ -14,11 +14,13 @@ def lambda_handler(event, context):
     data = fetch(start, end)
     report = format_terminal_output(data)
     report += fetch_reserved_instances()
+    report += fetch_reserved_utilization()
     print(report)
 
     print("retrieving slack secrets")
     secrets_client = boto3.client("secretsmanager")
-    secrets_response = secrets_client.get_secret_value(SecretId=os.getenv("SLACK_SECRETS_ARN"))
+    secrets_response = secrets_client.get_secret_value(
+        SecretId=os.getenv("SLACK_SECRETS_ARN"))
     secrets = json.loads(secrets_response['SecretString'])
     for channel, endpoint in secrets.items():
         print(f"publishing to {channel}")
@@ -31,7 +33,8 @@ def main():
         raise NotImplementedError("email reports are not yet implemented")
 
     if args.n_days:
-        start = aws_date_string(datetime.date.today() - datetime.timedelta(days=args.n_days))
+        start = aws_date_string(
+            datetime.date.today() - datetime.timedelta(days=args.n_days))
         end = aws_date_string(datetime.date.today())
     else:
         start = args.start
@@ -40,7 +43,7 @@ def main():
     data = fetch(start, end)
     report = format_terminal_output(data)
     report += fetch_reserved_instances()
-
+    report += fetch_reserved_utilization()
     if args.slack is not None:
         for endpoint in args.slack:
             send_to_slack(endpoint, report)
@@ -49,7 +52,8 @@ def main():
 
 def parse_arguments(arguments=None):
     """Parse arguments from the command line, validate them, and return them."""
-    parser = argparse.ArgumentParser("dontspendtoomuch", description="Report on AWS usage")
+    parser = argparse.ArgumentParser(
+        "dontspendtoomuch", description="Report on AWS usage")
     parser.add_argument("--email", action="append",
                         help="Email address to send a report to. May be specified multiple times.")
     parser.add_argument("--slack", action="append",
@@ -69,13 +73,16 @@ def parse_arguments(arguments=None):
     if not args.n_days and not args.start and not args.end:
         parser.error("Either --n-days or --start and --end must be provided.")
     if args.n_days and (args.end or args.start):
-        parser.error("If --n-days is provided, then --start and --end must be left blank.")
+        parser.error(
+            "If --n-days is provided, then --start and --end must be left blank.")
 
     if args.end and not args.start:
-        parser.error("If --end is provided, then --start must be provided too.")
+        parser.error(
+            "If --end is provided, then --start must be provided too.")
 
     if args.start and not args.end:
-        parser.error("If --start is provided, then --end must be provided too.")
+        parser.error(
+            "If --start is provided, then --end must be provided too.")
 
     if args.start and args.end:
         try:
@@ -133,17 +140,35 @@ def fetch_reserved_instances():
         items.append(li)
 
     items.sort()
-    all = tabulate.tabulate(items, headers=["expires", "type", "zone", "count", "offering"])
+    all = tabulate.tabulate(
+        items, headers=["expires", "type", "zone", "count", "offering"])
     all = "\n\n      Reserved Instance Report for us-west-2\n\n" + all
     return all
 
-"""
-def send_to_slack(webhook_url, report):
-    payload = {
-        "text": report,
-    }
-    requests.post(webhook_url, json=payload)
-"""
+
+def fetch_reserved_utilization():
+    ce = boto3.client('ce')
+    start = aws_date_string(datetime.date.today() - datetime.timedelta(days=30))
+    end = aws_date_string(datetime.date.today())
+
+    resp = ce.get_reservation_utilization(
+        TimePeriod={
+            "Start": start,
+            "End": end
+        }
+    )
+    total = resp["Total"]
+    report = f"""
+
+    ****  30 day reserved utilization report 
+    Percentage of all reservations actually utilized: {total["UtilizationPercentage"]}
+    On Demand Cost for these items: ${total["OnDemandCostOfRIHoursUsed"]}
+    Realized Savings: ${total["RealizedSavings"]}
+    
+    """
+    return report
+
+
 def send_to_slack(webhook_url, report):
     payload = {
         "text": "test to improve formatting",
@@ -159,6 +184,7 @@ def send_to_slack(webhook_url, report):
     }
     requests.post(webhook_url, json=payload)
 
+
 def format_terminal_output(report):
     """Format the response from a CostExplorer GetCostAndUsage report into a
     table."""
@@ -169,4 +195,3 @@ def format_terminal_output(report):
 
 if __name__ == "__main__":
     main()
-

--- a/dontspendtoomuch.py
+++ b/dontspendtoomuch.py
@@ -158,12 +158,15 @@ def fetch_reserved_utilization():
         }
     )
     total = resp["Total"]
+    util = float(total["UtilizationPercentage"])
+    od_cost = float(total["OnDemandCostOfRIHoursUsed"])
+    savings = float(total["RealizedSavings"])
     report = f"""
 
     ****  30 day reserved utilization report 
-    Percentage of all reservations actually utilized: {total["UtilizationPercentage"]}
-    On Demand Cost for these items: ${total["OnDemandCostOfRIHoursUsed"]}
-    Realized Savings: ${total["RealizedSavings"]}
+    Percentage of all reservations actually utilized: {util:.2f}
+    On Demand Cost for these items: ${od_cost:.2f}
+    Realized Savings: ${savings:.2f}
     
     """
     return report

--- a/dontspendtoomuch.py
+++ b/dontspendtoomuch.py
@@ -13,6 +13,7 @@ def lambda_handler(event, context):
     end = aws_date_string(datetime.date.today())
     data = fetch(start, end)
     report = format_terminal_output(data)
+    report += fetch_reserved_instances()
     print(report)
 
     print("retrieving slack secrets")
@@ -37,8 +38,9 @@ def main():
         end = args.end
 
     data = fetch(start, end)
-
     report = format_terminal_output(data)
+    report += fetch_reserved_instances()
+
     if args.slack is not None:
         for endpoint in args.slack:
             send_to_slack(endpoint, report)
@@ -52,7 +54,6 @@ def parse_arguments(arguments=None):
                         help="Email address to send a report to. May be specified multiple times.")
     parser.add_argument("--slack", action="append",
                         help="Slack Webhook URL to send a report to. May be specified multiple times.")
-
     parser.add_argument("--start",
                         help="Oldest date to include in the report, in YYYY-MM-DD format.")
     parser.add_argument("--end",
@@ -106,6 +107,33 @@ def fetch(start, end):
         Granularity="DAILY",
         Metrics=["UNBLENDED_COST"],
     )
+
+
+def fetch_reserved_instances():
+    """ Fetch reserved instnace information so we see when things expire"""
+    # Initialize the EC2 client
+    ec2 = boto3.client('ec2')
+
+    # Fetch all reserved instances
+    response = ec2.describe_reserved_instances()
+    reserved_instances = response['ReservedInstances']
+
+    items = []
+    for ri in reserved_instances:
+        instance_type = ri['InstanceType']
+        zone = ri['AvailabilityZone']
+
+        date = ri['End']
+        expires = f"{date.year}-{date.month}-{date.day}"
+        count = ri['InstanceCount']
+        offering = ri['OfferingClass']
+        li = f"until {expires} {instance_type}@{zone} ({count} instances) ({offering} offering)"
+        items.append(li)
+
+    items.sort
+    all = "\n".join(items)
+    all = "\n\n      Reserved Instance Report\n" + all
+    return all
 
 
 def send_to_slack(webhook_url, report):

--- a/dontspendtoomuch.py
+++ b/dontspendtoomuch.py
@@ -110,7 +110,7 @@ def fetch(start, end):
 
 
 def fetch_reserved_instances():
-    """ Fetch reserved instnace information so we see when things expire"""
+    """ Fetch reserved instance information so we see when things expire"""
     # Initialize the EC2 client
     ec2 = boto3.client('ec2')
 
@@ -121,27 +121,43 @@ def fetch_reserved_instances():
     items = []
     for ri in reserved_instances:
         instance_type = ri['InstanceType']
-        zone = ri['AvailabilityZone']
+        # State the availability zone when reservations are
+        # Specific to an availabliles zone...
+        zone = ri.get('AvailabilityZone', 'us-west-2')
 
         date = ri['End']
         expires = f"{date.year}-{date.month}-{date.day}"
         count = ri['InstanceCount']
         offering = ri['OfferingClass']
-        li = f"until {expires} {instance_type}@{zone} ({count} instances) ({offering} offering)"
+        li = [expires, instance_type, zone, count,  offering]
         items.append(li)
 
-    items.sort
-    all = "\n".join(items)
-    all = "\n\n      Reserved Instance Report\n" + all
+    items.sort()
+    all = tabulate.tabulate(items, headers=["expires", "type", "zone", "count", "offering"])
+    all = "\n\n      Reserved Instance Report for us-west-2\n\n" + all
     return all
 
-
+"""
 def send_to_slack(webhook_url, report):
     payload = {
         "text": report,
     }
     requests.post(webhook_url, json=payload)
-
+"""
+def send_to_slack(webhook_url, report):
+    payload = {
+        "text": "test to improve formatting",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "plain_text",
+                    "text": report
+                }
+            }
+        ]
+    }
+    requests.post(webhook_url, json=payload)
 
 def format_terminal_output(report):
     """Format the response from a CostExplorer GetCostAndUsage report into a
@@ -153,3 +169,4 @@ def format_terminal_output(report):
 
 if __name__ == "__main__":
     main()
+

--- a/dontspendtoomuch.tf
+++ b/dontspendtoomuch.tf
@@ -8,6 +8,14 @@ resource "aws_s3_bucket" "deployables" {
   acl = "private"
 }
 
+# Note that the following two data references have a bootstrapping problem. They
+# need to have the contents managed from outside of Terraform, since we want to
+# make modifications to them without running 'terraform apply.' That means that
+# they can't be 'resources', they need to be 'data' sources. In a clean start on
+# an empty AWS account, then, these keys will not exist.
+#
+# That means that the # Lambda will not be creatable though because these keys
+# won't exist.
 data "aws_s3_bucket_object" "script" {
   bucket = aws_s3_bucket.deployables.id
   key = "dontspendtoomuch/latest/script.zip"

--- a/dontspendtoomuch.tf
+++ b/dontspendtoomuch.tf
@@ -1,0 +1,106 @@
+provider "aws" {
+  region = "us-west-2"
+  allowed_account_ids = ["585193511743"]
+}
+
+resource "aws_secretsmanager_secret" "slack_hook_url" {
+  name = "dontspendtoomuch-slack-hook-url"
+  description = "Webhook URL for the dontspendtoomuch Slack app"
+  tags = {
+    Service = "dontspendtoomuch"
+    OwnerEmail = "swnelson@uw.edu"
+  }
+}
+
+resource "aws_lambda_function" "dontspendtoomuch" {
+  filename = "dontspendtoomuch-lambda.zip"
+  function_name = "dontspendtoomuch-daily"
+  handler = "dontspendtoomuch.lambda_handler"
+  runtime = "python3.8"
+  timeout = 120 // seconds
+  reserved_concurrent_executions = 1
+  role = aws_iam_role.dontspendtoomuch.arn
+  source_code_hash = filebase64sha256("dontspendtoomuch-lambda.zip")
+
+  environment {
+    variables = {
+      SLACK_SECRETS_ARN = aws_secretsmanager_secret.slack_hook_url.arn
+    }
+  }
+
+  tags = {
+    Service = "dontspendtoomuch"
+    OwnerEmail = "swnelson@uw.edu"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "dontspendtoomuch_daily" {
+  name = "/aws/lambda/dontspendtoomuch-daily"
+  retention_in_days = 14
+  tags = {
+    Service = "dontspendtoomuch"
+    OwnerEmail = "swnelson@uw.edu"
+  }
+}
+
+resource "aws_iam_role" "dontspendtoomuch" {
+  name = "hopDev-dontspendtoomuch"
+  permissions_boundary = "arn:aws:iam::585193511743:policy/NoIAM"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  tags = {
+    Service = "dontspendtoomuch"
+    OwnerEmail = "swnelson@uw.edu"
+  }
+}
+
+resource "aws_iam_policy" "dontspendtoomuch" {
+  name = "hopDev-dontspendtoomuch"
+  description = "Policy used by dontspendtoomuch, a bot which sends messages about how much we spend on AWS."
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowWritingLogs",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    },
+    {
+      "Sid": "AllowReadingSecretSlackURL",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "${aws_secretsmanager_secret.slack_hook_url.arn}"
+    },
+    {
+      "Sid": "AllowReadingCostUsage",
+      "Effect": "Allow",
+      "Action": "ce:GetCostAndUsage",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy_attachment" "dontspendtoomuch" {
+  role = aws_iam_role.dontspendtoomuch.name
+  policy_arn = aws_iam_policy.dontspendtoomuch.arn
+}

--- a/dontspendtoomuch.tf
+++ b/dontspendtoomuch.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_layer_version" "dependencies" {
   s3_key = data.aws_s3_bucket_object.dependencies.key
   s3_object_version = data.aws_s3_bucket_object.dependencies.version_id
 
-  compatible_runtimes = ["python3.6", "python3.7", "python3.8"]
+  compatible_runtimes = ["python3.8", "python3.10"]
 }
 
 resource "aws_lambda_function" "dontspendtoomuch" {

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from setuptools import setup
 install_requires = [
     "boto3",
     "tabulate",
-    "requests@git+https://github.com/psf/requests",
+    "requests"
 ]
 
 dev_requires = [
     "flake8",
     "autopep8",
-    "pytest",
+    "pytest"
 ]
 
 setup(


### PR DESCRIPTION
This is a big commit, centered around running dontspendtoomuch.py on Lambda. One part of it is writing Terraform to define infrastructure. That terraform file shouldn't live in this repo for long; it should move into the central scimma/aws-dev repository for a consistent state management strategy. But for now, here is fine.

Another part of it is work to create Lambda-style build artifacts. That's all done inside Make. The idea is just that we need to ship up a zip archive with the script and all of its dependencies.

Finally, there are some little changes to dontspendtoomuch.py. An entrypoint for lambda invocations is added, and a barebones send-to-slack function is added. That function doesn't do any formatting so it's not very useful just yet.

As of this commit, I have tfstate files stored locally. I am not sure it's worth setting up state management since we'll be moving the .tf file over to a different repo where that work is already done.